### PR TITLE
Enable deep sleep and add wakeup-source property

### DIFF
--- a/config/bakeneko60_go.conf
+++ b/config/bakeneko60_go.conf
@@ -1,1 +1,4 @@
 # Put configuration options here
+
+#Enable deep sleep support
+CONFIG_ZMK_SLEEP=y

--- a/config/boards/arm/bakeneko60_go/bakeneko60_go.dts
+++ b/config/boards/arm/bakeneko60_go/bakeneko60_go.dts
@@ -42,6 +42,7 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
+        wakeup-source;
         label = "KSCAN";
 
         diode-direction = "col2row";


### PR DESCRIPTION
This change is to decrease power consumption of keyboard. 
- [CONFIG_ZMK_SLEEP ](https://zmk.dev/docs/config/power#kconfig) enables deep sleep support.
- [wakeup-source;](https://zmk.dev/docs/features/soft-off#wakeup-sources) property to be able to wake up from sleep.

Issue #1